### PR TITLE
Moved to graceful-fs per Justin's request

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 var path = require("path");
-var fs = require("fs");
+var fs = require("graceful-fs");
 
 module.exports = {
     add: function(line, curData, scope, objects, currentWrite) {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "devDependencies": {
     "bit-docs-process-tags": "0.0.5",
     "mocha": ">= 1.18.0"
+  },
+  "dependencies": {
+    "graceful-fs": "^4.1.11"
   }
 }


### PR DESCRIPTION
This will prevent a `Too many open files error` with the native `fs` module.